### PR TITLE
Only support hex dependencies

### DIFF
--- a/lib/mix_audit/project.ex
+++ b/lib/mix_audit/project.ex
@@ -12,6 +12,7 @@ defmodule MixAudit.Project do
     |> read_lockfile()
     |> Map.values()
     |> Enum.map(&map_dependency(&1, lockfile))
+    |> Enum.reject(&is_nil/1)
   end
 
   defp read_lockfile(lockfile) do
@@ -27,13 +28,15 @@ defmodule MixAudit.Project do
     end
   end
 
-  defp map_dependency({_, package, version, _, _, _, _}, lockfile) do
+  defp map_dependency({:hex, package, version, _, _, _, _}, lockfile) do
     do_map_dependency(package, version, lockfile)
   end
 
-  defp map_dependency({_, package, version, _, _, _, _, _}, lockfile) do
+  defp map_dependency({:hex, package, version, _, _, _, _, _}, lockfile) do
     do_map_dependency(package, version, lockfile)
   end
+
+  defp map_dependency(_, _), do: nil
 
   defp do_map_dependency(package, version, lockfile) do
     %MixAudit.Dependency{package: to_string(package), version: version, lockfile: lockfile}

--- a/test/support/mix.lock
+++ b/test/support/mix.lock
@@ -1,3 +1,4 @@
 %{
   "plug": {:hex, :plug, "1.9.0", "8d7c4e26962283ff9f8f3347bd73838e2413fbc38b7bb5467d5924f68f3a5a4a", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm", "9902eda2c52ada2a096434682e99a2493f5d06a94d6ac6bcfff9805f952350f1"},
+  "distrillery": {:git, "https://github.com/bitwalker/distillery.git", "6700edb017804e51aec14dedb8df888d1db4e63c", [ref: "6700edb017804e51aec14dedb8df888d1db4e63c"]}
 }

--- a/test/support/mix.lock
+++ b/test/support/mix.lock
@@ -1,4 +1,4 @@
 %{
   "plug": {:hex, :plug, "1.9.0", "8d7c4e26962283ff9f8f3347bd73838e2413fbc38b7bb5467d5924f68f3a5a4a", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm", "9902eda2c52ada2a096434682e99a2493f5d06a94d6ac6bcfff9805f952350f1"},
-  "distrillery": {:git, "https://github.com/bitwalker/distillery.git", "6700edb017804e51aec14dedb8df888d1db4e63c", [ref: "6700edb017804e51aec14dedb8df888d1db4e63c"]}
+  "distillery": {:git, "https://github.com/bitwalker/distillery.git", "6700edb017804e51aec14dedb8df888d1db4e63c", [ref: "6700edb017804e51aec14dedb8df888d1db4e63c"]}
 }


### PR DESCRIPTION
For now, let’s just support Mix dependencies installed with `hex` since we can parse their version.

Thanks @aselder!

Fixes #1 