### PR TITLE
Add support for Elixir 1.8 and build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,22 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elixir-version: [1.10.x, 1.9.x, 1.8.x]
+        include:
+          - elixir-version: 1.10.x
+            otp-version: 22.x
+          - elixir-version: 1.9.x
+            otp-version: 21.x
+          - elixir-version: 1.8.x
+            otp-version: 20.x
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
         with:
-          otp-version: 22.2
-          elixir-version: 1.10.0
-      - run: mix deps.get
-      - run: mix format --check-formatted
-      - run: mix compile --warnings-as-errors --force
-      - run: mix credo --strict
-      - run: mix test
+          otp-version: ${{matrix.otp-version}}
+          elixir-version: ${{matrix.elixir-version}}
+      - run: make dependencies
+      - run: make lint
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+# Configuration
+# -------------
+
+APP_NAME = `grep 'app:' mix.exs | sed -e 's/\[//g' -e 's/ //g' -e 's/app://' -e 's/[:,]//g'`
+APP_VERSION = `grep '@version ' mix.exs | cut -d '"' -f2`
+GIT_REVISION = `git rev-parse HEAD`
+
+# Introspection targets
+# ---------------------
+
+.PHONY: help
+help: header targets
+
+.PHONY: header
+header:
+	@echo "\033[34mEnvironment\033[0m"
+	@echo "\033[34m---------------------------------------------------------------\033[0m"
+	@printf "\033[33m%-23s\033[0m" "APP_NAME"
+	@printf "\033[35m%s\033[0m" $(APP_NAME)
+	@echo ""
+	@printf "\033[33m%-23s\033[0m" "APP_VERSION"
+	@printf "\033[35m%s\033[0m" $(APP_VERSION)
+	@echo ""
+	@printf "\033[33m%-23s\033[0m" "GIT_REVISION"
+	@printf "\033[35m%s\033[0m" $(GIT_REVISION)
+	@echo "\n"
+
+.PHONY: targets
+targets:
+	@echo "\033[34mTargets\033[0m"
+	@echo "\033[34m---------------------------------------------------------------\033[0m"
+	@perl -nle'print $& if m{^[a-zA-Z_-]+:.*?## .*$$}' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+# Development targets
+# -------------------
+
+.PHONY: dependencies
+dependencies: ## Install dependencies
+	mix deps.get --force
+
+# CI targets
+# ----------
+
+.PHONY: lint
+lint: lint-compile lint-format lint-credo ## Run lint tools on the code
+
+.PHONY: lint-compile
+lint-compile:
+	mix compile --warnings-as-errors --force
+
+.PHONY: lint-format
+lint-format:
+	mix format --dry-run --check-formatted
+
+.PHONY: lint-credo
+lint-credo:
+	mix credo --strict
+
+.PHONY: test
+test: ## Run the test suite
+	mix test
+
+.PHONY: format
+format: ## Run formatting tools on the code
+	mix format

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule MixAudit.MixProject do
     [
       app: :mix_audit,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.8",
       description: "MixAudit provides a `mix deps.audit` task to scan a project Mix dependencies for known Elixir security vulnerabilities",
       source_url: "https://github.com/mirego/mix_audit",
       homepage_url: "https://github.com/mirego/mix_audit",


### PR DESCRIPTION
There is no reason `mix_audit` shouldn’t run correctly on Elixir 1.8. I also added a build matrix to make sure no backwards compabitle support is broken for Elixir 1.8.x and 1.9.x.

Fixes #3 