### PR TITLE
Avoid outputting empty patched version list

### DIFF
--- a/lib/mix_audit/formatting/human.ex
+++ b/lib/mix_audit/formatting/human.ex
@@ -24,7 +24,7 @@ defmodule MixAudit.Formatting.Human do
     #{colorized_text("CVE:", :red)} #{vulnerability.advisory.cve}
     #{colorized_text("URL:", :red)} #{vulnerability.advisory.url}
     #{colorized_text("Title:", :red)} #{String.trim(vulnerability.advisory.title)}
-    #{colorized_text("Patched versions:", :red)} #{Enum.join(vulnerability.advisory.patched_versions, ", ")}
+    #{colorized_text("Patched versions:", :red)} #{patched_versions(vulnerability.advisory.patched_versions)}
     """
   end
 
@@ -33,4 +33,7 @@ defmodule MixAudit.Formatting.Human do
     |> IO.ANSI.format()
     |> IO.chardata_to_string()
   end
+
+  defp patched_versions([]), do: "NONE"
+  defp patched_versions(versions), do: Enum.join(versions, ", ")
 end


### PR DESCRIPTION
If a security advisory doesn’t have a list of patched versions, we now output `NONE` when using the human format.

<img width="500" src="https://user-images.githubusercontent.com/11348/78237955-ffe95c00-74a9-11ea-8317-55ca39753b11.png">

Hat tip to @axelson for the suggestion 😄 

Fixes #5 