### PR TITLE
Gracefully exit when passing

### DIFF
--- a/lib/mix_audit/cli/audit.ex
+++ b/lib/mix_audit/cli/audit.ex
@@ -27,9 +27,7 @@ defmodule MixAudit.CLI.Audit do
     # Output the result
     IO.puts(String.trim(formatted_report))
 
-    if report.pass do
-      System.halt(0)
-    else
+    unless report.pass do
       System.halt(1)
     end
   end


### PR DESCRIPTION
## 📖 Description and reason

To streamline CI I have an alias setup like this:
```elixir
defp aliases do
  [
    ci: [
        "deps.audit",
        "test"
    ]
  ]
end
```
and I execute it using `mix ci`, but it stops after this line
```
No vulnerabilities found.
```

This PR enables the command to continue running if the `deps.audit` check passes.