### PR TITLE
Use new Elixir Security Advisory repository as source

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ $ mix deps.audit
 
 MixAudit builds two lists when it’s executed in a project:
 
-1. A list of security advisories fetched from the community-maintained [`elixir-security-advisories`](https://github.com/dependabot/elixir-security-advisories) repository
+1. A list of security advisories fetched from the GitHub-sourced [`elixir-security-advisories`](https://github.com/mirego/elixir-security-advisories) repository
 2. A list of Mix dependencies from the various `mix.lock` files in the project
 
-Then, it loops through each project dependency and tries to find security advisories that apply to it (through its package name) and that match its version specification (through the advisory patched and unaffected version policies).
+Then, it loops through each project dependency and tries to find security advisories that apply to it (through its package name) and that match its version specification (through the advisory vulnerable version ranges).
 
 If one is found, a **vulnerability** (the combination of a **security advisory** and a **project dependency**) is then added to the report.
 

--- a/lib/mix_audit/advisory.ex
+++ b/lib/mix_audit/advisory.ex
@@ -6,5 +6,6 @@ defmodule MixAudit.Advisory do
             url: nil,
             title: nil,
             description: nil,
-            vulnerable_version_ranges: []
+            vulnerable_version_ranges: [],
+            first_patched_versions: []
 end

--- a/lib/mix_audit/advisory.ex
+++ b/lib/mix_audit/advisory.ex
@@ -3,7 +3,6 @@ defmodule MixAudit.Advisory do
   defstruct id: nil,
             package: nil,
             disclosure_date: nil,
-            cve: nil,
             url: nil,
             title: nil,
             description: nil,

--- a/lib/mix_audit/advisory.ex
+++ b/lib/mix_audit/advisory.ex
@@ -7,6 +7,5 @@ defmodule MixAudit.Advisory do
             url: nil,
             title: nil,
             description: nil,
-            patched_versions: [],
-            unaffected_versions: []
+            vulnerable_version_ranges: []
 end

--- a/lib/mix_audit/audit.ex
+++ b/lib/mix_audit/audit.ex
@@ -17,8 +17,9 @@ defmodule MixAudit.Audit do
 
   defp is_vulnerability?(%MixAudit.Advisory{vulnerable_version_ranges: vulnerable_version_ranges}, %MixAudit.Dependency{version: version}) do
     Enum.any?(vulnerable_version_ranges, fn version_range ->
-      requirements = map_ranges_to_requirements(version_range)
-      Enum.all?(requirements, &Version.match?(version, &1))
+      version_range
+      |> map_ranges_to_requirements()
+      |> Enum.all?(&Version.match?(version, &1))
     end)
   end
 

--- a/lib/mix_audit/formatting/human.ex
+++ b/lib/mix_audit/formatting/human.ex
@@ -11,7 +11,7 @@ defmodule MixAudit.Formatting.Human do
   end
 
   defp map_vulnerabilities(vulnerabilities) do
-    Enum.map_join(vulnerabilities, &map_vulnerability/1, "\n")
+    Enum.map_join(vulnerabilities, "\n", &map_vulnerability/1)
   end
 
   defp map_vulnerability(vulnerability) do
@@ -21,7 +21,8 @@ defmodule MixAudit.Formatting.Human do
     #{colorized_text("Lockfile:", :red)} #{vulnerability.dependency.lockfile}
     #{colorized_text("URL:", :red)} #{vulnerability.advisory.url}
     #{colorized_text("Title:", :red)} #{String.trim(vulnerability.advisory.title)}
-    #{colorized_text("Patched versions:", :red)} #{patched_versions(vulnerability.advisory.patched_versions)}
+    #{colorized_text("Vulnerable versions:", :red)} #{versions(vulnerability.advisory.vulnerable_version_ranges)}
+    #{colorized_text("First patched versions:", :red)} #{versions(vulnerability.advisory.first_patched_versions)}
     """
   end
 
@@ -31,6 +32,6 @@ defmodule MixAudit.Formatting.Human do
     |> IO.chardata_to_string()
   end
 
-  defp patched_versions([]), do: "NONE"
-  defp patched_versions(versions), do: Enum.join(versions, ", ")
+  defp versions([]), do: "NONE"
+  defp versions(versions), do: Enum.join(versions, ", ")
 end

--- a/lib/mix_audit/formatting/human.ex
+++ b/lib/mix_audit/formatting/human.ex
@@ -19,7 +19,6 @@ defmodule MixAudit.Formatting.Human do
     #{colorized_text("Name:", :red)} #{vulnerability.dependency.package}
     #{colorized_text("Version:", :red)} #{vulnerability.dependency.version}
     #{colorized_text("Lockfile:", :red)} #{vulnerability.dependency.lockfile}
-    #{colorized_text("CVE:", :red)} #{vulnerability.advisory.cve}
     #{colorized_text("URL:", :red)} #{vulnerability.advisory.url}
     #{colorized_text("Title:", :red)} #{String.trim(vulnerability.advisory.title)}
     #{colorized_text("Patched versions:", :red)} #{patched_versions(vulnerability.advisory.patched_versions)}

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -1,5 +1,5 @@
 defmodule MixAudit.Repo do
-  @url "https://github.com/dependabot/elixir-security-advisories.git"
+  @url "https://github.com/mirego/elixir-security-advisories.git"
 
   def advisories do
     synchronize()
@@ -25,7 +25,7 @@ defmodule MixAudit.Repo do
   end
 
   defp path do
-    Path.join([System.get_env("HOME"), ".local", "share", "elixir-security-advisories"])
+    Path.join([System.get_env("HOME"), ".local", "share", "elixir-security-advisories-mirego"])
   end
 
   defp package_advisories_path do
@@ -43,8 +43,7 @@ defmodule MixAudit.Repo do
       url: advisory_data["link"],
       title: advisory_data["title"],
       description: advisory_data["description"],
-      patched_versions: advisory_data["patched_versions"] || [],
-      unaffected_versions: advisory_data["unaffected_versions"] || []
+      vulnerable_version_ranges: advisory_data["vulnerable_version_ranges"]
     }
   end
 end

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -42,7 +42,8 @@ defmodule MixAudit.Repo do
       url: advisory_data["link"],
       title: advisory_data["title"],
       description: advisory_data["description"],
-      vulnerable_version_ranges: advisory_data["vulnerable_version_ranges"]
+      vulnerable_version_ranges: advisory_data["vulnerable_version_ranges"],
+      first_patched_versions: advisory_data["first_patched_versions"]
     }
   end
 end

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -39,7 +39,6 @@ defmodule MixAudit.Repo do
       id: advisory_data["id"],
       package: advisory_data["package"],
       disclosure_date: advisory_data["disclosure_date"],
-      cve: advisory_data["cve"],
       url: advisory_data["link"],
       title: advisory_data["title"],
       description: advisory_data["description"],

--- a/test/mix_audit/audit_test.exs
+++ b/test/mix_audit/audit_test.exs
@@ -2,6 +2,8 @@ defmodule MixAudit.AuditTest do
   use ExUnit.Case
   doctest MixAudit.Audit
 
+  alias MixAudit.Audit
+
   test "report/2 includes vulnerabilities based on vulnerable version ranges" do
     dependencies = [
       %MixAudit.Dependency{
@@ -25,7 +27,7 @@ defmodule MixAudit.AuditTest do
       ]
     }
 
-    report = MixAudit.Audit.report(dependencies, advisories)
+    report = Audit.report(dependencies, advisories)
     [first_vulnerability | _] = report.vulnerabilities
 
     refute report.pass
@@ -57,7 +59,7 @@ defmodule MixAudit.AuditTest do
       ]
     }
 
-    report = MixAudit.Audit.report(dependencies, advisories)
+    report = Audit.report(dependencies, advisories)
     [first_vulnerability | _] = report.vulnerabilities
 
     refute report.pass
@@ -89,7 +91,7 @@ defmodule MixAudit.AuditTest do
       ]
     }
 
-    report = MixAudit.Audit.report(dependencies, advisories)
+    report = Audit.report(dependencies, advisories)
 
     assert report.pass
     assert report.vulnerabilities == []

--- a/test/mix_audit/audit_test.exs
+++ b/test/mix_audit/audit_test.exs
@@ -16,7 +16,7 @@ defmodule MixAudit.AuditTest do
     advisories = %{
       "foo" => [
         %MixAudit.Advisory{
-          cve: "1",
+          id: "ABC-123",
           description: "Bar",
           title: "Foo",
           package: "foo",
@@ -31,7 +31,7 @@ defmodule MixAudit.AuditTest do
     [first_vulnerability | _] = report.vulnerabilities
 
     refute report.pass
-    assert first_vulnerability.advisory.cve == "1"
+    assert first_vulnerability.advisory.id == "ABC-123"
     assert first_vulnerability.dependency.package == "foo"
     assert first_vulnerability.dependency.version == "0.7.4"
   end
@@ -48,7 +48,7 @@ defmodule MixAudit.AuditTest do
     advisories = %{
       "foo" => [
         %MixAudit.Advisory{
-          cve: "1",
+          id: "ABC-123",
           description: "Bar",
           title: "Foo",
           package: "foo",
@@ -63,7 +63,7 @@ defmodule MixAudit.AuditTest do
     [first_vulnerability | _] = report.vulnerabilities
 
     refute report.pass
-    assert first_vulnerability.advisory.cve == "1"
+    assert first_vulnerability.advisory.id == "ABC-123"
     assert first_vulnerability.dependency.package == "foo"
     assert first_vulnerability.dependency.version == "0.7.4"
   end
@@ -80,7 +80,7 @@ defmodule MixAudit.AuditTest do
     advisories = %{
       "foo" => [
         %MixAudit.Advisory{
-          cve: "1",
+          id: "ABC-123",
           description: "Bar",
           title: "Foo",
           package: "foo",

--- a/test/mix_audit/audit_test.exs
+++ b/test/mix_audit/audit_test.exs
@@ -2,7 +2,7 @@ defmodule MixAudit.AuditTest do
   use ExUnit.Case
   doctest MixAudit.Audit
 
-  test "report/2 includes vulnerabilities based on patched versions" do
+  test "report/2 includes vulnerabilities based on vulnerable version ranges" do
     dependencies = [
       %MixAudit.Dependency{
         package: "foo",
@@ -20,10 +20,7 @@ defmodule MixAudit.AuditTest do
           package: "foo",
           disclosure_date: "1970-01-01",
           url: "https://example.com",
-          patched_versions: [
-            "> 1.0.0"
-          ],
-          unaffected_versions: []
+          vulnerable_version_ranges: ["~> 0.7.2"]
         }
       ]
     }
@@ -37,7 +34,7 @@ defmodule MixAudit.AuditTest do
     assert first_vulnerability.dependency.version == "0.7.4"
   end
 
-  test "report/2 excludes vulnerabilities based on unaffected versions" do
+  test "report/2 includes vulnerabilities based on complex vulnerable version ranges" do
     dependencies = [
       %MixAudit.Dependency{
         package: "foo",
@@ -55,12 +52,39 @@ defmodule MixAudit.AuditTest do
           package: "foo",
           disclosure_date: "1970-01-01",
           url: "https://example.com",
-          patched_versions: [
-            "> 1.0.0"
-          ],
-          unaffected_versions: [
-            "0.7.4"
-          ]
+          vulnerable_version_ranges: ["> 0.7.2, < 0.7.9"]
+        }
+      ]
+    }
+
+    report = MixAudit.Audit.report(dependencies, advisories)
+    [first_vulnerability | _] = report.vulnerabilities
+
+    refute report.pass
+    assert first_vulnerability.advisory.cve == "1"
+    assert first_vulnerability.dependency.package == "foo"
+    assert first_vulnerability.dependency.version == "0.7.4"
+  end
+
+  test "report/2 does not include vulnerabilities based on complex vulnerable version ranges" do
+    dependencies = [
+      %MixAudit.Dependency{
+        package: "foo",
+        version: "0.7.4",
+        lockfile: "mix.lock"
+      }
+    ]
+
+    advisories = %{
+      "foo" => [
+        %MixAudit.Advisory{
+          cve: "1",
+          description: "Bar",
+          title: "Foo",
+          package: "foo",
+          disclosure_date: "1970-01-01",
+          url: "https://example.com",
+          vulnerable_version_ranges: ["> 0.7.5, < 0.7.9", "= 0.7.3"]
         }
       ]
     }
@@ -68,5 +92,6 @@ defmodule MixAudit.AuditTest do
     report = MixAudit.Audit.report(dependencies, advisories)
 
     assert report.pass
+    assert report.vulnerabilities == []
   end
 end


### PR DESCRIPTION
## 📖 Description and reason

Since its beginning, MixAudit has been using the [dependabot/elixir-security-advisories](https://github.com/dependabot/elixir-security-advisories) repository as its source of truth. The repository has been archived in the last month in favor of the much more powerful [GitHub Advisory Database](https://github.com/advisories) which is even queryable through GitHub‘s GraphQL API.

However, because it’s a tool intended to be ran anywhere by anyone, MixAudit _still needs_ a publicly accessible (GitHub‘s GraphQL API requires authentication) repository that stores Elixir security advisories. This is why we created [mirego/elixir-security-advisories](https://github.com/mirego/elixir-security-advisories), a 100% automatically maintained repository that uses GHA as its source of truth.

Since the data exposed by GitHub is a little bit different from the format that was stored by [dependabot/elixir-security-advisories](https://github.com/dependabot/elixir-security-advisories), I had to change small parts of MixAudit.

## 👷 Work done

#### Tasks

- [x] Change source for advisories
- [x] Adapt version matching engine to match GitHub version ranges

## 🦀 Dispatch

`#dispatch/elixir`
