### PR TITLE
Add explicit Git requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         elixir-version: [1.12.x, 1.11.x, 1.10.x, 1.9.x, 1.8.x]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        elixir-version: [1.12.x, 1.11.x, 1.10.x, 1.9.x, 1.8.x]
+        elixir-version: [1.14.x, 1.13.x, 1.12.x, 1.11.x, 1.10.x, 1.9.x, 1.8.x]
         include:
+          - elixir-version: 1.14.x
+            otp-version: 25.x
+          - elixir-version: 1.13.x
+            otp-version: 25.x
           - elixir-version: 1.12.x
             otp-version: 24.x
           - elixir-version: 1.11.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       HEX_API_KEY: ${{ secrets.MIREGO_HEXPM_API_KEY }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       HEX_API_KEY: ${{ secrets.MIREGO_HEXPM_API_KEY }}
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 24.x
-          elixir-version: 1.13.x
+          otp-version: 25.x
+          elixir-version: 1.14.x
       - run: mix deps.get
       - run: mix compile --docs
       - run: mix hex.publish --yes

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ $ mix escript.install hex mix_audit
 
 The only difference is that instead of using the `mix deps.audit` task, you will have to use the created executable.
 
+## Requirements
+
+- [Git](https://git-scm.com)
+- [Elixir](https://elixir-lang.org/) ~1.8
+
 ## Usage
 
 To generate a security report, you can use the `deps.audit` Mix task:

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -16,7 +16,7 @@ defmodule MixAudit.Repo do
       previous_path = File.cwd!()
       File.cd(repo_path)
 
-      System.cmd("lgit", ["pull", "--rebase", "--quiet", "origin", "main"])
+      System.cmd("git", ["pull", "--rebase", "--quiet", "origin", "main"])
 
       File.cd(previous_path)
     else

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -22,6 +22,9 @@ defmodule MixAudit.Repo do
     else
       System.cmd("git", ["clone", "--quiet", @url, repo_path])
     end
+  rescue
+    _ ->
+      raise RuntimeError, message: "It looks like `git` is not installed. Please install it and run `mix deps.audit` again."
   end
 
   defp path do

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -16,7 +16,7 @@ defmodule MixAudit.Repo do
       previous_path = File.cwd!()
       File.cd(repo_path)
 
-      System.cmd("git", ["pull", "--rebase", "--quiet", "origin", "main"])
+      System.cmd("lgit", ["pull", "--rebase", "--quiet", "origin", "main"])
 
       File.cd(previous_path)
     else
@@ -24,7 +24,7 @@ defmodule MixAudit.Repo do
     end
   rescue
     _ ->
-      raise RuntimeError, message: "It looks like `git` is not installed. Please install it and run `mix deps.audit` again."
+      reraise RuntimeError, message: "It looks like `git` is not installed. Please install it and run `mix deps.audit` again."
   end
 
   defp path do


### PR DESCRIPTION
## 📖 Description and reason

We need Git to pull the security advisories database.

## 👷 Work done

#### Tasks

- [x] Add better error handling in repo synchronization function
- [x] Add explicit Git requirement in `README.md`

#### Additional notes

This should close #18.

## 🎉 Result

```shell
# With Git installed
$ mix deps.audit
No vulnerabilities found.

# Without Git installed
$ mix deps.audit
** (RuntimeError) It looks like `git` is not installed. Please install it and run `mix deps.audit` again.
    (mix_audit 2.0.2) lib/mix_audit/repo.ex:27: MixAudit.Repo.synchronize/0
    (mix_audit 2.0.2) lib/mix_audit/repo.ex:5: MixAudit.Repo.advisories/0
    (mix_audit 2.0.2) lib/mix_audit/cli/audit.ex:11: MixAudit.CLI.Audit.run/1
    (mix 1.14.0) lib/mix/task.ex:421: anonymous fn/3 in Mix.Task.run_task/4
    (mix 1.14.0) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

## 🦀 Dispatch

`#dispatch/elixir`
