### PR TITLE
Remove `rescue` statement in `Repo.synchronize/0`

### DIFF
--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -22,9 +22,6 @@ defmodule MixAudit.Repo do
     else
       System.cmd("git", ["clone", "--quiet", @url, repo_path])
     end
-  rescue
-    _ ->
-      reraise RuntimeError, message: "It looks like `git` is not installed. Please install it and run `mix deps.audit` again."
   end
 
   defp path do


### PR DESCRIPTION
## 📖 Description and reason

I added a `rescue` statement a while back to print a more explicit message in case `git` was not available on the system.

However, it has a nasty side effect: it swallows other errors that can occur within the function. It’s better to [let it crash](https://elixir-lang.org/getting-started/try-catch-and-rescue.html#fail-fast--let-it-crash) 🤓

## 👷 Work done

#### Tasks

- [x] Remove `rescue` to see whole errors

## 🦀 Dispatch

`#dispatch/elixir`
