### PR TITLE
Support elixir 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,10 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        elixir-version: [1.15.x, 1.14.x, 1.13.x, 1.12.x]
+        elixir-version: [1.16.x, 1.15.x, 1.14.x, 1.13.x, 1.12.x]
         include:
+          - elixir-version: 1.16.x
+            otp-version: 26.x
           - elixir-version: 1.15.x
             otp-version: 26.x
           - elixir-version: 1.14.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 26.x
-          elixir-version: 1.15.x
+          elixir-version: 1.16.x
       - run: mix deps.get
       - run: mix compile --docs
       - run: mix hex.publish --yes

--- a/lib/mix_audit/project.ex
+++ b/lib/mix_audit/project.ex
@@ -16,7 +16,10 @@ defmodule MixAudit.Project do
   end
 
   defp read_lockfile(lockfile) do
-    opts = [file: lockfile, warn_on_unnecessary_quotes: false]
+    # Backwards compatibility: suppressing warnings needs to be done with two different options:
+    # - emit_warnings: from Elixir v1.16 onwards
+    # - warn_on_unnecessary_quotes: up to Elixir v1.15
+    opts = [file: lockfile, emit_warnings: false, warn_on_unnecessary_quotes: false]
 
     with {:ok, contents} <- File.read(lockfile),
          assert_no_merge_conflicts_in_lockfile(lockfile, contents),


### PR DESCRIPTION
## 📖 Description and reason

<!-- What are the changes and why are they necessary? -->
Goal: support Elixir 1.16.

Reason: API changes in Elixir 1.16 in [Code.string_to_quoted/2](https://hexdocs.pm/elixir/1.16.0/Code.html#string_to_quoted/2).

Changes:
*  Add Elixir 1.16 in GitHub Actions workflows
* Support Elixir 1.16 in call to `Code.string_to_quoted/2`

Fixes #25 .

## 👷 Work done

- Provide fix

## 🎉 Result

`mix deps.audit` should run on Elixir 1.16 without unnecessary warnings.

## 🦀 Dispatch

`#dispatch/elixir`
