### PR TITLE
Add ignore file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ mix deps.audit
 | `--format`               | String | `"human"`           | The format of the report to generate (`"json"` or `"human"`) |
 | `--ignore-advisory-ids`  | String | `""`                | Comma-separated list of advisory IDs to ignore               |
 | `--ignore-package-names` | String | `""`                | Comma-separated list of package names to ignore              |
-| `--ignore-file`          | String | `.mix-audit-skips`  | Path of the ignore file                                      |
+| `--ignore-file`          | String | `""`                | Path of the ignore file                                      |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $ mix deps.audit
 | `--format`               | String | `"human"`           | The format of the report to generate (`"json"` or `"human"`) |
 | `--ignore-advisory-ids`  | String | `""`                | Comma-separated list of advisory IDs to ignore               |
 | `--ignore-package-names` | String | `""`                | Comma-separated list of package names to ignore              |
+| `--ignore-file`          | String | `.mix-audit-skips`  | Path of the ignore file                                      |
 
 ## Example
 

--- a/lib/mix_audit/cli.ex
+++ b/lib/mix_audit/cli.ex
@@ -5,6 +5,7 @@ defmodule MixAudit.CLI do
         switches: [
           ignore_advisory_ids: :string,
           ignore_package_names: :string,
+          ignore_file: :string,
           version: :boolean,
           help: :boolean,
           format: :string,

--- a/lib/mix_audit/cli/audit.ex
+++ b/lib/mix_audit/cli/audit.ex
@@ -51,15 +51,8 @@ defmodule MixAudit.CLI.Audit do
   defp ignored_ids_from_file(opts) do
     opts
     |> Keyword.get(:ignore_file, ".mix-audit-skips")
-    |> File.read()
-    |> case do
-      {:ok, content} ->
-        content
-        |> String.split("\n")
-        |> Enum.reject(fn line -> String.starts_with?(line, "#") or line == "" end)
-
-      _ ->
-        []
-    end
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.reject(fn line -> String.starts_with?(line, "#") || String.trim(line) == "" end)
   end
 end

--- a/lib/mix_audit/cli/audit.ex
+++ b/lib/mix_audit/cli/audit.ex
@@ -54,7 +54,8 @@ defmodule MixAudit.CLI.Audit do
         []
 
       ignore_file ->
-        File.read!(ignore_file)
+        ignore_file
+        |> File.read!()
         |> String.split("\n")
         |> Enum.reject(fn line -> String.starts_with?(line, "#") || String.trim(line) == "" end)
     end

--- a/lib/mix_audit/cli/audit.ex
+++ b/lib/mix_audit/cli/audit.ex
@@ -48,11 +48,15 @@ defmodule MixAudit.CLI.Audit do
     |> Enum.map(&String.trim/1)
   end
 
-  defp ignored_ids_from_file(opts) do
-    opts
-    |> Keyword.get(:ignore_file, ".mix-audit-skips")
-    |> File.read!()
-    |> String.split("\n")
-    |> Enum.reject(fn line -> String.starts_with?(line, "#") || String.trim(line) == "" end)
+  def ignored_ids_from_file(opts) do
+    case Keyword.get(opts, :ignore_file) do
+      nil ->
+        []
+
+      ignore_file ->
+        File.read!(ignore_file)
+        |> String.split("\n")
+        |> Enum.reject(fn line -> String.starts_with?(line, "#") || String.trim(line) == "" end)
+    end
   end
 end

--- a/lib/mix_audit/cli/help.ex
+++ b/lib/mix_audit/cli/help.ex
@@ -9,7 +9,7 @@ defmodule MixAudit.CLI.Help do
     IO.puts("--format                The format of the report to generate (human, json)")
     IO.puts("--ignore-advisory-ids   A comma-separated list of advisory IDs to ignore")
     IO.puts("--ignore-package-names  A comma-separated list of package names to ignore")
-    IO.puts("--ignore-file           Path of the ignore file (default .mix-audit-skips)")
+    IO.puts("--ignore-file           Path of the ignore file")
     IO.puts("")
     System.halt(0)
   end

--- a/lib/mix_audit/cli/help.ex
+++ b/lib/mix_audit/cli/help.ex
@@ -9,6 +9,7 @@ defmodule MixAudit.CLI.Help do
     IO.puts("--format                The format of the report to generate (human, json)")
     IO.puts("--ignore-advisory-ids   A comma-separated list of advisory IDs to ignore")
     IO.puts("--ignore-package-names  A comma-separated list of package names to ignore")
+    IO.puts("--ignore-file           Path of the ignore file (default .mix-audit-skips)")
     IO.puts("")
     System.halt(0)
   end


### PR DESCRIPTION
## 📖 Description and reason

Add an option to use a file for ignoring CVEs
Similar to bundler audit config file
https://github.com/rubysec/bundler-audit?tab=readme-ov-file#configuration-file

<!-- What are the changes and why are they necessary? -->

## 👷 Work done

[x] add option to get `ignore-file` path
[x] default file (if found) in `.mix-audit-skips`, similar to to [sobelow](https://github.com/nccgroup/sobelow) lib (feel free to propose a better name)
[ ] tests
[x] Documentation

#### Additional notes

I would like to add some tests, but as far as I understood there are not so many covering the cli. Do you think is important to add some tests?

## 🎉 Result

Correctly ignoring CVEs stored in `.mix-audit-skips` file (if correctly formatted)

## 🦀 Dispatch

`#dispatch/elixir`
