### PR TITLE
Fail closed when the advisory mirror cannot be synchronized

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ $ mix deps.audit
 | `--ignore-package-names` | String | `""`                | Comma-separated list of package names to ignore              |
 | `--ignore-file`          | String | `""`                | Path of the ignore file                                      |
 
+> **Note:** The security advisories are fetched at runtime by cloning/pulling
+> the [advisory mirror](https://github.com/mirego/elixir-security-advisories)
+> into `~/.local/share/elixir-security-advisories-mirego`. There is no bundled
+> fallback, so if this synchronization fails (for example, the directory is not
+> writable or the network is unavailable) the audit would otherwise run against
+> an empty advisory set and report no vulnerabilities. To avoid passing
+> silently, mix_audit fails closed: it prints the git failure to stderr and
+> exits with a non-zero status instead.
+
 ## Example
 
 <img src="https://user-images.githubusercontent.com/11348/76112291-ea1e6f00-5faf-11ea-8337-6656d765b7fc.png">

--- a/lib/mix_audit/cli/audit.ex
+++ b/lib/mix_audit/cli/audit.ex
@@ -1,14 +1,34 @@
 defmodule MixAudit.CLI.Audit do
   def run(opts) do
+    # Synchronize the advisory mirror. The advisory database is fetched at
+    # runtime with no bundled fallback, so a failed synchronization would
+    # otherwise leave the audit scanning against an empty advisory set and
+    # passing silently. Always fail closed: surface the git failure and exit
+    # non-zero instead of reporting no vulnerabilities.
+    case MixAudit.Repo.synchronize() do
+      {:error, reason} ->
+        IO.puts(:stderr, format_sync_error(reason))
+        # Use halt/1 rather than stop/1 so the non-zero exit status is
+        # guaranteed: stop/1 is asynchronous and can race with Mix's own normal
+        # (status 0) shutdown, which would defeat the point of failing closed.
+        # The diagnostic above is already flushed synchronously to stderr.
+        System.halt(1)
+
+      :ok ->
+        audit(opts)
+    end
+  end
+
+  defp audit(opts) do
     # Get and sanitize options
     path = Path.expand(Keyword.get(opts, :path, "."))
     format = Keyword.get(opts, :format)
     ignored_advisory_ids = ignored_advisory_ids(opts)
     ignored_package_names = ignored_package_names(opts)
 
-    # Synchronize and get security advisories
+    # Get security advisories
     advisories =
-      MixAudit.Repo.advisories()
+      MixAudit.Repo.read_advisories()
       |> Enum.reject(&(&1.id in ignored_advisory_ids))
       |> Enum.group_by(& &1.package)
 
@@ -64,5 +84,12 @@ defmodule MixAudit.CLI.Audit do
     |> Keyword.get(:ignore_package_names, "")
     |> String.split(",")
     |> Enum.map(&String.trim/1)
+  end
+
+  defp format_sync_error({:git, exit_status, output}) do
+    trimmed_output = String.trim(to_string(output))
+
+    "Failed to synchronize the security advisories mirror (git exited with status #{exit_status})." <>
+      if(trimmed_output == "", do: "", else: "\n" <> trimmed_output)
   end
 end

--- a/lib/mix_audit/repo.ex
+++ b/lib/mix_audit/repo.ex
@@ -1,27 +1,58 @@
 defmodule MixAudit.Repo do
   @url "https://github.com/mirego/elixir-security-advisories.git"
 
+  @doc """
+  Synchronizes the local advisory mirror and returns the parsed advisories.
+
+  Synchronization failures are ignored so that a previously cloned mirror (or an
+  empty result) is still usable. Callers that need to detect a failed
+  synchronization should call `synchronize/0` explicitly.
+  """
   def advisories do
     synchronize()
 
+    read_advisories()
+  end
+
+  @doc """
+  Synchronizes the local advisory mirror with the upstream repository.
+
+  Returns `:ok` when the underlying `git` command succeeds, or
+  `{:error, {:git, exit_status, output}}` when it fails (for example when the
+  mirror directory is not writable or the network is unavailable). Because the
+  advisory database is fetched at runtime with no bundled fallback, a failed
+  synchronization otherwise leaves the audit scanning against an empty advisory
+  set and passing silently.
+  """
+  def synchronize(repo_path \\ path()) do
+    {output, exit_status} =
+      if File.dir?(repo_path) do
+        previous_path = File.cwd!()
+        File.cd(repo_path)
+
+        result = System.cmd("git", ["pull", "--rebase", "--quiet", "origin", "main"], stderr_to_stdout: true)
+
+        File.cd(previous_path)
+
+        result
+      else
+        System.cmd("git", ["clone", "--quiet", @url, repo_path], stderr_to_stdout: true)
+      end
+
+    case exit_status do
+      0 -> :ok
+      status -> {:error, {:git, status, output}}
+    end
+  end
+
+  @doc """
+  Reads and parses the advisories currently present in the local mirror without
+  synchronizing first. Returns an empty list when the mirror is absent.
+  """
+  def read_advisories do
     package_advisories_path()
     |> Path.wildcard()
     |> Enum.map(&map_advisory/1)
-  end
-
-  defp synchronize do
-    repo_path = path()
-
-    if File.dir?(repo_path) do
-      previous_path = File.cwd!()
-      File.cd(repo_path)
-
-      System.cmd("git", ["pull", "--rebase", "--quiet", "origin", "main"])
-
-      File.cd(previous_path)
-    else
-      System.cmd("git", ["clone", "--quiet", @url, repo_path])
-    end
   end
 
   defp path do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MixAudit.MixProject do
   use Mix.Project
 
-  @version "2.1.5"
+  @version "2.2.0"
 
   def project do
     [

--- a/test/mix_audit/repo_test.exs
+++ b/test/mix_audit/repo_test.exs
@@ -1,8 +1,54 @@
 defmodule MixAudit.RepoTest do
   use ExUnit.Case
-  doctest MixAudit.Repo
+
+  alias MixAudit.Repo
+
+  doctest Repo
 
   test "advisories/0 returns a map of security advisories" do
-    assert is_list(MixAudit.Repo.advisories())
+    assert is_list(Repo.advisories())
+  end
+
+  test "read_advisories/0 returns a list without synchronizing" do
+    assert is_list(Repo.read_advisories())
+  end
+
+  describe "synchronize/1" do
+    test "returns an error tuple when the mirror directory is not writable" do
+      # Reproduce the CI failure: the parent of the mirror directory is not
+      # writable, so git cannot create the mirror and exits non-zero. This must
+      # be surfaced as an error rather than silently ignored.
+      parent = Path.join(System.tmp_dir!(), "mix_audit_readonly_#{System.unique_integer([:positive])}")
+      File.mkdir!(parent)
+      File.chmod!(parent, 0o555)
+
+      on_exit(fn ->
+        File.chmod(parent, 0o755)
+        File.rm_rf(parent)
+      end)
+
+      repo_path = Path.join(parent, "mirror")
+
+      # Skip when the permission restriction is not effective (e.g. running as
+      # root, which ignores directory permission bits), since git would succeed.
+      if writable?(repo_path) do
+        IO.puts("Skipping: directory permissions are not enforced (running as root?)")
+      else
+        assert {:error, {:git, exit_status, output}} = Repo.synchronize(repo_path)
+        assert is_integer(exit_status) and exit_status != 0
+        assert is_binary(output)
+      end
+    end
+  end
+
+  defp writable?(path) do
+    case File.mkdir(path) do
+      :ok ->
+        File.rmdir(path)
+        true
+
+      {:error, _} ->
+        false
+    end
   end
 end


### PR DESCRIPTION
The advisory database is fetched at runtime by cloning/pulling the mirror into `~/.local/share/elixir-security-advisories-mirego`, with no bundled fallback. `MixAudit.Repo.synchronize/0` discarded git's exit status, so a failed clone/pull (e.g. the directory is not writable, as happens when CI containers run as a non-root user with an injected HOME, or the network is unavailable) left the audit scanning against an empty advisory set and reporting 'No vulnerabilities found.' with exit 0 — failing open.

- `Repo.synchronize/1` now returns `:ok | {:error, {:git, status, output}}`, capturing git's exit status and output.
- `Repo.read_advisories/0` reads the mirror without synchronizing, so the CLI synchronizes explicitly and inspects the result.
- The CLI now **always fails closed**: any git failure (clone or pull) is printed to stderr and exits non-zero, instead of passing silently. This is unconditional — there is no opt-in flag to remember.
- Uses `System.halt/1` rather than the asynchronous `System.stop/1` so the non-zero exit status is guaranteed and cannot race Mix's normal shutdown.